### PR TITLE
fix(settings): 新建提供商未填写内容退出不再落库空记录

### DIFF
--- a/app/src/main/java/com/aicode/feature/settings/presentation/component/ProviderEditorScreen.kt
+++ b/app/src/main/java/com/aicode/feature/settings/presentation/component/ProviderEditorScreen.kt
@@ -147,7 +147,17 @@ fun ProviderEditorScreen(
         useResponseApi = useResponseApi
     )
 
+    // 新建场景下判断用户是否填写了实质内容：名称、API Key、Base URL 任一非空白，或已添加模型。
+    // 全空白时退出不应落库，否则会存入一条名为“新提供商”的空记录。
+    fun hasSubstantiveInput(): Boolean =
+        initialProvider != null ||
+            name.isNotBlank() ||
+            apiKey.isNotBlank() ||
+            baseUrl.isNotBlank() ||
+            models.isNotEmpty()
+
     fun saveCurrent() {
+        if (!hasSubstantiveInput()) return
         onSave(currentConfig())
     }
 


### PR DESCRIPTION
退出编辑器时 saveCurrent() 无条件落库，导致用户新建提供商后什么都没填
就按返回键，会存入一条名为「新提供商」、无 API Key 无模型的空记录。
新增 hasSubstantiveInput() 判断：新建场景下名称/Key/Base URL 全空白且 未加模型时跳过保存；编辑已有提供商不受影响。