### PR TITLE
fix(db): 兼容历史迁移编号，避免启动时重复添加列

### DIFF
--- a/app/src/main/java/com/aicode/core/db/MigrationLoader.kt
+++ b/app/src/main/java/com/aicode/core/db/MigrationLoader.kt
@@ -18,12 +18,24 @@ class FileMigration(
                     "executed_at INTEGER)"
         )
         for (sql in sqlStatements) {
-            if (sql.isNotBlank()) {
+            if (sql.isBlank()) continue
+            try {
                 db.execSQL(sql)
+            } catch (e: Exception) {
+                // 旧包把 proxy/sort 编成 42/43，新包改成 44/45 后会重复 ADD COLUMN。
+                if (SchemaCatchUp.isDuplicateColumnMessage(e.message)) {
+                    FileLogger.w(
+                        "MigrationLoader",
+                        "Skip already-applied column in $scriptName: $sql"
+                    )
+                } else {
+                    throw e
+                }
             }
         }
+        SchemaCatchUp.ensure(db)
         db.execSQL(
-            "INSERT INTO migration_history (version, script_name, executed_at) VALUES (?, ?, ?)",
+            "INSERT OR REPLACE INTO migration_history (version, script_name, executed_at) VALUES (?, ?, ?)",
             arrayOf<Any>(version, scriptName, System.currentTimeMillis())
         )
         FileLogger.i("MigrationLoader", "Applied migration: $scriptName")
@@ -35,27 +47,27 @@ object MigrationLoader {
         val assetManager = context.assets
         val migrationsDir = "migrations"
         val files = runCatching { assetManager.list(migrationsDir) }.getOrNull() ?: emptyArray()
-        
+
         val migrations = mutableListOf<Migration>()
-        
+
         // File format: {version}_{description}.sql, e.g., "7_add_workspace_path.sql"
         for (fileName in files) {
             if (!fileName.endsWith(".sql")) continue
-            
+
             val versionStr = fileName.substringBefore('_')
             val version = versionStr.toIntOrNull() ?: continue
-            
+
             val sqlContent = runCatching {
                 assetManager.open("$migrationsDir/$fileName").bufferedReader().use { it.readText() }
             }.getOrNull() ?: continue
-            
+
             val statements = sqlContent.split(";")
                 .map { it.trim() }
                 .filter { it.isNotEmpty() }
-            
+
             migrations.add(FileMigration(version, fileName, statements))
         }
-        
+
         return migrations.toTypedArray()
     }
 }

--- a/app/src/main/java/com/aicode/core/db/SchemaCatchUp.kt
+++ b/app/src/main/java/com/aicode/core/db/SchemaCatchUp.kt
@@ -1,0 +1,85 @@
+package com.aicode.core.db
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.aicode.core.util.FileLogger
+
+/**
+ * 补齐历史上被改号/重排过的加法迁移列。
+ *
+ * 1.10.1 曾把 session_parent / provider_proxy / provider_sort_order
+ * 编成 41/42/43，随后又在中间插入 thinking_blocks / cache_creation，
+ * 把这三项改成 43/44/45。已升到旧 43 的库再跑新 44 会
+ * `duplicate column name: proxyEnabled`，同时永远跳过 41/42 的新列。
+ */
+object SchemaCatchUp {
+
+    data class AdditiveColumn(
+        val table: String,
+        val name: String,
+        val definition: String
+    )
+
+    val requiredColumns: List<AdditiveColumn> = listOf(
+        AdditiveColumn("agent_messages", "thinkingBlocksJson", "TEXT DEFAULT NULL"),
+        AdditiveColumn("llm_call_records", "cacheCreationTokens", "INTEGER NOT NULL DEFAULT 0"),
+        AdditiveColumn("chat_sessions", "parentId", "TEXT DEFAULT NULL"),
+        AdditiveColumn("chat_sessions", "subagentType", "TEXT DEFAULT NULL"),
+        AdditiveColumn("ai_providers", "proxyEnabled", "INTEGER NOT NULL DEFAULT 0"),
+        AdditiveColumn("ai_providers", "proxyType", "TEXT NOT NULL DEFAULT 'HTTP'"),
+        AdditiveColumn("ai_providers", "proxyHost", "TEXT NOT NULL DEFAULT ''"),
+        AdditiveColumn("ai_providers", "proxyPort", "INTEGER NOT NULL DEFAULT 0"),
+        AdditiveColumn("ai_providers", "proxyUsername", "TEXT NOT NULL DEFAULT ''"),
+        AdditiveColumn("ai_providers", "proxyPassword", "TEXT NOT NULL DEFAULT ''"),
+        AdditiveColumn("ai_providers", "sortOrder", "INTEGER NOT NULL DEFAULT 0")
+    )
+
+    fun isDuplicateColumnMessage(message: String?): Boolean {
+        return message.orEmpty().contains("duplicate column name", ignoreCase = true)
+    }
+
+    fun existingColumns(db: SupportSQLiteDatabase, table: String): Set<String> {
+        val result = mutableSetOf<String>()
+        db.query("PRAGMA table_info(`$table`)").use { cursor ->
+            val nameIndex = cursor.getColumnIndex("name")
+            while (cursor.moveToNext()) {
+                if (nameIndex >= 0) {
+                    result.add(cursor.getString(nameIndex))
+                }
+            }
+        }
+        return result
+    }
+
+    fun tableExists(db: SupportSQLiteDatabase, table: String): Boolean {
+        db.query(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1",
+            arrayOf(table)
+        ).use { cursor ->
+            return cursor.moveToFirst()
+        }
+    }
+
+    fun ensure(db: SupportSQLiteDatabase) {
+        for ((table, columns) in requiredColumns.groupBy { it.table }) {
+            if (!tableExists(db, table)) continue
+            val existing = existingColumns(db, table)
+            for (column in columns) {
+                if (column.name in existing) continue
+                val sql = "ALTER TABLE `$table` ADD COLUMN `${column.name}` ${column.definition}"
+                try {
+                    db.execSQL(sql)
+                    FileLogger.i("SchemaCatchUp", "Added missing column ${table}.${column.name}")
+                } catch (e: Exception) {
+                    if (isDuplicateColumnMessage(e.message)) {
+                        FileLogger.w(
+                            "SchemaCatchUp",
+                            "Column already present: ${table}.${column.name}"
+                        )
+                    } else {
+                        throw e
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/aicode/di/AgentModule.kt
+++ b/app/src/main/java/com/aicode/di/AgentModule.kt
@@ -68,6 +68,7 @@ import javax.inject.Named
 import javax.inject.Singleton
 
 import com.aicode.core.db.MigrationLoader
+import com.aicode.core.db.SchemaCatchUp
 import com.aicode.feature.agent.domain.checkpoint.CheckpointManager
 import com.aicode.feature.agent.domain.session.MessagePersistenceUseCase
 import com.aicode.feature.agent.domain.session.SessionUseCase
@@ -97,6 +98,11 @@ object AgentModule {
             AgentDatabase::class.java,
             "aicode_agent_db"
         ).addMigrations(*MigrationLoader.loadMigrations(context))
+            .addCallback(object : androidx.room.RoomDatabase.Callback() {
+                override fun onOpen(db: SupportSQLiteDatabase) {
+                    SchemaCatchUp.ensure(db)
+                }
+            })
             .fallbackToDestructiveMigration(dropAllTables = false)
             .build()
     }

--- a/app/src/test/java/com/aicode/core/db/FileMigrationTest.kt
+++ b/app/src/test/java/com/aicode/core/db/FileMigrationTest.kt
@@ -1,6 +1,8 @@
 package com.aicode.core.db
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class FileMigrationTest {
@@ -51,5 +53,31 @@ class FileMigrationTest {
             statements[0]
         )
         assertEquals("-- 注释\nALTER TABLE sample ADD COLUMN data TEXT", statements[1])
+    }
+
+    @Test
+    fun duplicateColumnMessage_matchesSqliteError() {
+        assertTrue(
+            SchemaCatchUp.isDuplicateColumnMessage(
+                "duplicate column name: proxyEnabled (code 1 SQLITE_ERROR)"
+            )
+        )
+        assertTrue(
+            SchemaCatchUp.isDuplicateColumnMessage(
+                "SQLiteException: Duplicate column name: sortOrder"
+            )
+        )
+        assertFalse(SchemaCatchUp.isDuplicateColumnMessage("no such table: ai_providers"))
+        assertFalse(SchemaCatchUp.isDuplicateColumnMessage(null))
+    }
+
+    @Test
+    fun requiredColumns_coverRenumberedMigrations() {
+        val names = SchemaCatchUp.requiredColumns.map { "${it.table}.${it.name}" }.toSet()
+        assertTrue(names.contains("agent_messages.thinkingBlocksJson"))
+        assertTrue(names.contains("llm_call_records.cacheCreationTokens"))
+        assertTrue(names.contains("chat_sessions.parentId"))
+        assertTrue(names.contains("ai_providers.proxyEnabled"))
+        assertTrue(names.contains("ai_providers.sortOrder"))
     }
 }


### PR DESCRIPTION
## 问题

部分旧版本数据库曾使用 41/42/43 表示 session_parent、provider_proxy、provider_sort_order。后续版本在 41/42 插入 thinking_blocks 和 cache_creation 后，将原迁移改为 43/44/45。

已升级到旧版本 43 的用户安装新 APK 时，迁移 44 会再次执行 `ALTER TABLE ai_providers ADD COLUMN proxyEnabled`，触发 `duplicate column name: proxyEnabled`，应用随后进入 CrashActivity，无法正常启动。

## 修复

- 新增 `SchemaCatchUp`，按实际表结构补齐所有新增列，兼容迁移编号重排。
- `FileMigration` 对重复列迁移做幂等处理。
- 数据库打开时再次执行结构补齐，覆盖旧库已记录迁移但缺少新列的情况。
- 增加迁移兼容性单元测试。

已在 Android 16 arm64 设备验证：原本启动即崩溃的数据库升级后可进入 `MainActivity`，数据库升级到版本 45，原有数据保留。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migrations by skipping blank statements and continuing safely when duplicate-column errors occur.
  * Added automatic recovery for missing additive database columns when the database opens.
  * Improved migration history updates to prevent duplicate records.
  * Other database errors continue to be reported normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->